### PR TITLE
DCE-76: Improving & Measuring MV ordering

### DIFF
--- a/src/engine/board/mv_gen.rs
+++ b/src/engine/board/mv_gen.rs
@@ -382,18 +382,13 @@ impl BoardGenMoveTrait for Board {
     }
 
     fn quiet_eval(&mut self, mv: &Move) -> isize {
-        if self.make_move(mv) {
-            let key = self.key();
-            self.undo_move();
-
-            if matches!(self.s_pv[self.ply()], Some(k) if k == key) {
-                return PV_MV_SCORE;
-            }
-
-            // if let Some(_) = TT.read().unwrap().get(key) {
-            //     return 92500;
-            // }
+        if matches!(self.pv_moves[0][self.ply()], Some(pv_mv) if *mv == pv_mv) {
+            return PV_MV_SCORE;
         }
+
+        // if matches!(self.tt_mv, Some(tt_mv) if *mv == tt_mv.mv) {
+        //     return TT_MV_SCORE;
+        // }
 
         if matches!(self.s_killers[self.ply()][0], Some(x) if x == *mv) {
             return KILLER_MV_SCORE[0];
@@ -406,18 +401,13 @@ impl BoardGenMoveTrait for Board {
     }
 
     fn capture_eval(&mut self, mv: &Move) -> isize {
-        if self.make_move(mv) {
-            let key = self.key();
-            self.undo_move();
-
-            if matches!(self.s_pv[self.ply()], Some(k) if k == key) {
-                return PV_MV_SCORE;
-            }
-
-            // if let Some(_) = TT.read().unwrap().get(key) {
-            //     return 92500;
-            // }
+        if matches!(self.pv_moves[0][self.ply()], Some(pv_mv) if *mv == pv_mv) {
+            return PV_MV_SCORE;
         }
+
+        // if matches!(self.tt_mv, Some(tt_mv) if *mv == tt_mv.mv) {
+        //     return TT_MV_SCORE;
+        // }
 
         let see = self.see(mv.from as usize, mv.to as usize);
         if see >= 0 {

--- a/src/engine/search/quiescence.rs
+++ b/src/engine/search/quiescence.rs
@@ -25,9 +25,9 @@ impl Search {
         }
 
         // NOTE: DELTA PRUNING
-        if eval < alpha - BIG_DELTA {
-            return alpha;
-        }
+        // if eval < alpha - BIG_DELTA {
+        //     return alpha;
+        // }
 
         // if let Some((score, _)) =
         //     TT.read().unwrap().probe(self.board.state.key, 0, alpha as i16, beta as i16)
@@ -37,7 +37,7 @@ impl Search {
 
         let mut pos_rev = self.board.gen_captures();
         // let ply = self.board.ply();
-        // self.pv_len[ply] = ply;
+        // self.board.pv_len[ply] = ply;
 
         while let Some(rev) = next_move(&mut pos_rev) {
             if (self.info.nodes & 2047) == 0 && time_over(&self) {
@@ -55,11 +55,11 @@ impl Search {
                     return beta;
                 }
                 alpha = score;
-                // self.pv_moves[ply][ply] = Some(rev);
-                // for j in (ply + 1)..self.pv_len[ply + 1] {
-                //     self.pv_moves[ply][j] = self.pv_moves[ply + 1][j];
+                // self.board.pv_moves[ply][ply] = Some(rev);
+                // for j in (ply + 1)..self.board.pv_len[ply + 1] {
+                //     self.board.pv_moves[ply][j] = self.board.pv_moves[ply + 1][j];
                 // }
-                // self.pv_len[ply] = self.pv_len[ply + 1];
+                // self.board.pv_len[ply] = self.board.pv_len[ply + 1];
             }
         }
 


### PR DESCRIPTION
# Jira Ticket: DCE-76
## Summary (Provide a summary of the changes.)
- Improved  MV ordering by removing Make Move, Undo Move from mv-gen.rs
- Added More metrics to determine if I have a good move ordering.

## Checklist
- [x] All Tests are Correct.
- [x] Merged with the master branch.

## Additional Notes (Any additional context, screenshots, or relevant information.)

