### PR TITLE
DCE-94: Fix the Transposition Table and add to the Quiescence Search

### DIFF
--- a/src/engine/board/make_move.rs
+++ b/src/engine/board/make_move.rs
@@ -27,6 +27,7 @@ impl BoardMoveTrait for Board {
     fn make_move(&mut self, mv: &Move) -> bool {
         self.history.push(self.state);
         self.moves.push(*mv);
+        self.zb_reset_key();
 
         match mv.flag {
             Flag::Quiet => self.quiet_mv(mv.from as usize, mv.to as usize, mv.piece),
@@ -177,8 +178,6 @@ impl BoardMoveTrait for Board {
     }
 
     fn make_state(&mut self, mv: &Move) {
-        self.zb_reset_key();
-
         // Switch the color
         self.state.color.change_color();
         self.zb_clr();

--- a/src/engine/board/mv_gen.rs
+++ b/src/engine/board/mv_gen.rs
@@ -846,7 +846,6 @@ mod tests {
         }
 
         println!("Curr Key: {:?}", board.key());
-        print_chess(&board);
 
         assert_eq!(board.is_repetition(), true);
     }
@@ -855,6 +854,22 @@ mod tests {
     fn test_is_repetition_v2() {
         let mut board = Board::read_fen(&FEN_START);
         let moves = ["e2e4", "e7e5", "b1c3", "b8c6", "c3b1", "c6b8"];
+
+        println!("{:?}", board.key());
+
+        for (idx, notation) in moves.iter().enumerate() {
+            let mv = from_move_notation(&notation, &mut board);
+            board.make_move(&mv);
+            println!("{:?}", board.key());
+        }
+
+        assert_eq!(board.is_repetition(), false);
+    }
+
+    #[test]
+    fn test_is_repetition_v4() {
+        let mut board = Board::read_fen(&FEN_START);
+        let moves = ["e2e4", "e7e5", "b1c3", "b8c6", "c3b1", "c6b8", "b1c3"];
 
         println!("{:?}", board.key());
 

--- a/src/engine/board/structures/zobrist.rs
+++ b/src/engine/board/structures/zobrist.rs
@@ -37,10 +37,9 @@ impl ZobristKeysTrait for Board {
     }
 
     fn zb_ep(&mut self) {
-        // FIXME: This is wrong, it should be fixed
-        // if let Some(idx) = self.state.ep {
-        //     self.state.key ^= EP_KEYS[idx as usize]
-        // }
+        if let Some(idx) = self.state.ep {
+            self.state.key ^= EP_KEYS[idx as usize]
+        }
     }
 }
 

--- a/src/engine/misc/display/display_moves.rs
+++ b/src/engine/misc/display/display_moves.rs
@@ -18,7 +18,7 @@ pub fn print_move_list(moves: &[(Move, isize)]) {
     }
 }
 
-pub fn get_move_list(moves: &[Move], depth: u8) -> String {
+pub fn get_move_list(moves: &[Move], depth: i8) -> String {
     let mut move_list_resp: String = String::new();
     for (idx, mv) in moves.iter().enumerate() {
         // FIXME: When refactoring decide if this should be removed

--- a/src/engine/misc/display/display_stats.rs
+++ b/src/engine/misc/display/display_stats.rs
@@ -3,7 +3,7 @@ use crate::engine::search::iter_deepening::Search;
 pub trait DisplayStatsTrait {
     fn print_info(&self, score: isize, line: String);
     fn print_pruning_info(&self, score: isize);
-    fn print_ordering_info(&self, depth: u8);
+    fn print_ordering_info(&self, depth: i8);
 }
 
 impl DisplayStatsTrait for Search {
@@ -22,7 +22,7 @@ impl DisplayStatsTrait for Search {
         );
     }
 
-    fn print_ordering_info(&self, depth: u8) {
+    fn print_ordering_info(&self, depth: i8) {
         let avg_beta_idx = self.info.beta_cut_index_sum[depth as usize] as f64
             / (self.info.beta_cut_count[depth as usize] + 1) as f64;
 

--- a/src/engine/protocols/uci.rs
+++ b/src/engine/protocols/uci.rs
@@ -23,7 +23,7 @@ pub struct NewUCI {
     pub time_limit: Option<Duration>,
     pub moves_togo: usize,
     pub infinite: bool,
-    pub max_depth: u8,
+    pub max_depth: i8,
     pub moves_played: usize,
     pub quit: bool,
     pub stopped: bool,
@@ -176,7 +176,7 @@ impl UCI {
     fn go(&mut self, args: &[&str]) {
         self.abort_search();
 
-        let mut depth: Option<u8> = None;
+        let mut depth: Option<i8> = None;
         let mut infinite = false;
         let mut time_limit: Option<Duration> = None;
 

--- a/src/engine/search/alpha_beta.rs
+++ b/src/engine/search/alpha_beta.rs
@@ -16,13 +16,13 @@ impl Search {
         &mut self,
         mut alpha: isize,
         beta: isize,
-        mut depth: u8,
+        mut depth: i8,
         take_null: bool,
         is_pvs: bool,
     ) -> isize {
         // If we reached the final depth than make sure there is no horizon effect
         if depth == 0 {
-            return self.quiescence_search(alpha, beta);
+            return self.quiescence_search(alpha, beta, depth);
         }
 
         // Check if the position happened before or is draw

--- a/src/engine/search/iter_deepening.rs
+++ b/src/engine/search/iter_deepening.rs
@@ -15,7 +15,7 @@ const MIN_INF: isize = isize::MIN / 2;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SearchInfo {
     pub nodes: usize,
-    pub curr_depth: u8,
+    pub curr_depth: i8,
     pub curr_key: u64,
 
     pub fail_hard: usize,
@@ -69,7 +69,7 @@ impl Search {
         self.board.pv_clear();
     }
 
-    pub fn set_curr_depth(&mut self, depth: u8) {
+    pub fn set_curr_depth(&mut self, depth: i8) {
         self.info.curr_depth = depth;
     }
 }
@@ -122,7 +122,7 @@ mod tests {
 
     use super::*;
 
-    fn test_search(fen: &str, depth: u8, expected_pv: &str) {
+    fn test_search(fen: &str, depth: i8, expected_pv: &str) {
         let uci = Arc::new(RwLock::new(NewUCI::init()));
         uci.write().unwrap().max_depth = depth;
         let board = Board::read_fen(fen);

--- a/src/engine/search/transposition_table.rs
+++ b/src/engine/search/transposition_table.rs
@@ -25,13 +25,13 @@ pub struct TTEntry {
     pub key: u64,
     pub mv: Move,
     pub score: i16,
-    pub depth: u8,
+    pub depth: i8,
     pub category: Bound,
-    pub age: u16,
+    pub age: i16,
 }
 
 impl TTEntry {
-    pub fn init(key: u64, mv: Move, score: i16, depth: u8, category: Bound, age: u16) -> Self {
+    pub fn init(key: u64, mv: Move, score: i16, depth: i8, category: Bound, age: i16) -> Self {
         Self { key, mv, score, depth, category, age }
     }
 }
@@ -43,7 +43,7 @@ pub struct TTTable {
     pub inserts: u64,
     pub hits: u64,
     pub collisions: u64,
-    pub curr_age: u16,
+    pub curr_age: i16,
 }
 
 impl TTTable {
@@ -62,7 +62,7 @@ impl TTTable {
         return (key % MAX_TT_ENTRIES as u64) as usize;
     }
 
-    pub fn set(&mut self, key: u64, mv: Move, score: i16, depth: u8, category: Bound) {
+    pub fn set(&mut self, key: u64, mv: Move, score: i16, depth: i8, category: Bound) {
         self.inserts += 1;
 
         if let Some(entry) = self.table[Self::idx(key)] {
@@ -78,11 +78,11 @@ impl TTTable {
             Some(TTEntry::init(key, mv, score, depth, category, self.curr_age));
     }
 
-    pub fn probe(&self, key: u64, depth: u8, mut alpha: i16, mut beta: i16) -> Option<(i16, Move)> {
+    pub fn probe(&self, key: u64, depth: i8, mut alpha: i16, mut beta: i16) -> Option<(i16, Move)> {
         // self.lookups += 1;
         let idx = Self::idx(key);
         if let Some(e) = self.table[idx] {
-            if e.key == key && (e.depth + e.age as u8) >= (depth + self.curr_age as u8) {
+            if e.key == key && (e.depth as i16 + e.age) >= (depth as i16 + self.curr_age) {
                 match e.category {
                     Bound::Lower => alpha = alpha.max(e.score),
                     Bound::Exact => {


### PR DESCRIPTION
# Jira Ticket: DCE-94
## Summary (Provide a summary of the changes.)
- Added the Transposition table to the Quiesence Search.
- Fixed Zobrist En Passant Bug. 
- Changed type of depth from u8 to i8.

## Checklist
- [x] All Tests are Correct.
- [x] Merged with the master branch.

## Additional Notes (Any additional context, screenshots, or relevant information.)

